### PR TITLE
Fixed opener after learn updated how pdfs are displayed

### DIFF
--- a/src/opener.ts
+++ b/src/opener.ts
@@ -7,12 +7,11 @@ import { SYNC_KEYS, WORK_NOTIFICATION_MESSAGE_ID } from './constant'
     return
   }
 
-  console.log('LEARN PDF auto opener injected!')
-  const pageObjects = document.getElementsByTagName('object')
-  for (const obj of pageObjects) {
-    if (obj.type === 'application/pdf' && obj.data.startsWith('http')) {
-      await chrome.runtime.sendMessage(WORK_NOTIFICATION_MESSAGE_ID)
-      window.location.replace(obj.data)
-    }
+  console.log('LEARN PDF auto opener injected!');
+  const iframe = document.querySelector('iframe#resourceobject');
+  if (iframe && iframe.src.startsWith('http')) {
+      await chrome.runtime.sendMessage(WORK_NOTIFICATION_MESSAGE_ID);
+      window.location.replace(iframe.src);
   }
 })()
+

--- a/src/opener.ts
+++ b/src/opener.ts
@@ -8,7 +8,7 @@ import { SYNC_KEYS, WORK_NOTIFICATION_MESSAGE_ID } from './constant'
   }
 
   console.log('LEARN PDF auto opener injected!');
-  const iframe = document.querySelector('iframe#resourceobject');
+  const iframe = document.querySelector('.resourcepdf > iframe#resourceobject');
   if (iframe && iframe.src.startsWith('http')) {
       await chrome.runtime.sendMessage(WORK_NOTIFICATION_MESSAGE_ID);
       window.location.replace(iframe.src);


### PR DESCRIPTION
I found that the extension was not working, `pageObjects` was returning an empty list and so it seems like learn has updated how the pdfs are displayed on the page. The change to search for iframes with id 'resourceobject' looks to be working again.